### PR TITLE
Unregister for push for iOS workaround

### DIFF
--- a/everlive-push-hybrid/.abproject
+++ b/everlive-push-hybrid/.abproject
@@ -4,26 +4,7 @@
   "AppIdentifier": "com.telerik.PushNotificationApp",
   "ProjectName": "everlive-push-hybrid",
   "AndroidPermissions": [
-    "android.permission.ACCESS_COARSE_LOCATION",
-    "android.permission.ACCESS_FINE_LOCATION",
-    "android.permission.ACCESS_LOCATION_EXTRA_COMMANDS",
-    "android.permission.ACCESS_NETWORK_STATE",
-    "android.permission.ACCOUNT_MANAGER",
-    "android.permission.BROADCAST_STICKY",
-    "android.permission.CAMERA",
-    "android.permission.GET_ACCOUNTS",
-    "android.permission.GET_TASKS",
-    "android.permission.INTERNET",
-    "android.permission.MANAGE_ACCOUNTS",
-    "android.permission.MODIFY_AUDIO_SETTINGS",
-    "android.permission.READ_CONTACTS",
-    "android.permission.READ_PHONE_STATE",
-    "android.permission.RECEIVE_SMS",
-    "android.permission.RECORD_AUDIO",
-    "android.permission.VIBRATE",
-    "android.permission.WAKE_LOCK",
-    "android.permission.WRITE_CONTACTS",
-    "android.permission.WRITE_EXTERNAL_STORAGE"
+    "android.permission.INTERNET"
   ],
   "DeviceOrientations": [
     "Portrait",
@@ -32,7 +13,6 @@
   "iOSStatusBarStyle": "Default",
   "AndroidHardwareAcceleration": "true",
   "BundleVersion": "1.0",
-  "iOSDisplayName": "",
   "iOSDeviceFamily": [
     "1",
     "2"

--- a/everlive-push-hybrid/scripts/main.js
+++ b/everlive-push-hybrid/scripts/main.js
@@ -1,11 +1,11 @@
-(function (global) {
+(function(global) {
     'use strict';
 
     var app = global.app = global.app || {};
 
-    app.MainViewModel = (function () {
+    app.MainViewModel = (function() {
 
-        var _onDeviceIsRegistered = function () {
+        var _onDeviceIsRegistered = function() {
             app.hideLoading();
 
             $('#registerButton').hide();
@@ -20,16 +20,16 @@
             $('#registerButton').show();
             $('#unregisterButton').hide();
         };
-        
+
         var onAndroidPushReceived = function(args) {
             alert('Android notification received: ' + JSON.stringify(args));
         };
-        
+
         var onIosPushReceived = function(args) {
             alert('iOS notification received: ' + JSON.stringify(args));
         };
-        
-        var onWP8PushReceived = function (args) {
+
+        var onWP8PushReceived = function(args) {
             alert('Windows Phone notification received: ' + JSON.stringify(args));
         };
 
@@ -47,7 +47,7 @@
                 wp8: {
                     channelName: 'EverlivePushChannel'
                 },
-                notificationCallbackAndroid : onAndroidPushReceived,
+                notificationCallbackAndroid: onAndroidPushReceived,
                 notificationCallbackIOS: onIosPushReceived,
                 notificationCallbackWP8: onWP8PushReceived,
                 customParameters: {
@@ -60,7 +60,7 @@
             app.everlive.push.register(pushSettings)
                 .then(
                     _onDeviceIsRegistered,
-                    function (err) {
+                    function(err) {
                         app.hideLoading();
                         alert('REGISTER ERROR: ' + JSON.stringify(err));
                     }
@@ -68,16 +68,30 @@
         };
 
         var unregisterFromPush = function() {
+            var unregisterPromise;
+
             app.showLoading();
 
-            app.everlive.push.unregister()
-                .then(
-                    _onDeviceUnregistered,
-                    function(err) {
-                        app.hideLoading();
-                        alert('UNREGISTER ERROR: ' + JSON.stringify(err));
-                    }
-                );
+            if (device.platform.toLowerCase() === 'ios') {
+                // Unregisters the current device from push notifications in Telerik Backend Services only.
+                // After this call completes successfully, Backend Services will no longer send notifications to this device.
+                // Note that this does not prevent the device from receiving notifications and does not invalidate push tokens.
+
+                // This avoids using the native iOS "unregisterForRemoteNotifications" method which according to Apple's documentation,
+                // should be called in rare circumstances only, such as when a new version of the app removes support for all types of remote notifications.
+                unregisterPromise = app.everlive.push.currentDevice().unregister();
+            } else {
+                // Use push.unregister() to invalidates any push tokens and unregister from Telerik Backend Services
+                unregisterPromise = app.everlive.push.unregister();
+            }
+
+            unregisterPromise.then(
+                _onDeviceUnregistered,
+                function(err) {
+                    app.hideLoading();
+                    alert('UNREGISTER ERROR: ' + JSON.stringify(err));
+                }
+            );
         };
 
         return {


### PR DESCRIPTION
Removes only Telerik Platform registratiоn to solve iOS 10 unregister problems.
Removed unnecessary Android permissions.